### PR TITLE
Yearly Meeting 2023-12-16: Removal of Closed Ballot when Voting

### DIFF
--- a/stadgar.typ
+++ b/stadgar.typ
@@ -123,8 +123,9 @@ Eventuella icke-medlemmar kan, vid beslut, adjungeras in med närvaro och
 yttranderätt, men inte rösträtt.
 
 Samtliga beslut fattas genom acklamation. Varje deltagare med rösträtt har rätt
-att begära sluten votering. Om inte annat beslutats gäller enkel majoritet.
-Beslut där mer än enkel majoritet krävs skall fattas genom sluten votering.
+att begära en votering eller sluten votering. Om inte annat beslutats gäller
+enkel majoritet. Beslut där mer än enkel majoritet krävs skall fattas genom
+sluten votering.
 
 == Val
 Årsmötet väljer nästa års styrelse, revisor och valberedning.


### PR DESCRIPTION
Motion title is misleading: amendment makes it so closed ballot voting is still allowed to be requested, this just adds the alternative for members to request normal "counted" votes (i.e., not acclamation).