### PR TITLE
Yearly Meeting 2023-12-16: Voting for more than Simple Majority Required

### DIFF
--- a/stadgar.typ
+++ b/stadgar.typ
@@ -124,7 +124,7 @@ yttranderätt, men inte rösträtt.
 
 Samtliga beslut fattas genom acklamation. Varje deltagare med rösträtt har rätt
 att begära sluten votering. Om inte annat beslutats gäller enkel majoritet.
-Beslut där mer än enkel majoritet krävs skall fattas genom sluten votering.
+Beslut där mer än enkel majoritet krävs skall fattas genom votering.
 
 == Val
 Årsmötet väljer nästa års styrelse, revisor och valberedning.


### PR DESCRIPTION
This motion makes it so a simple "counted" vote (i.e., not acclamation) is sufficient for decisions that require more than a simple majority (vs. the secret ballot method currently required).